### PR TITLE
Fixing toggles in letterboxd.com.css

### DIFF
--- a/websites/letterboxd.com.css
+++ b/websites/letterboxd.com.css
@@ -6,17 +6,17 @@ body, .site-body, footer {
   background-image: none !important;
 }
 
-/* lb-Better-Text-Color */
+/* lb-Better Text Color */
 p {
   color: #a0b0be !important;
 }
 
-/* lb-Hide-Footer */
+/* lb-Hide Footer */
 footer {
   display: none !important;
 }
 
-/* lb-Fade-Background-Image */ 
+/* lb-Fade Background Image */ 
 .backdropimage {
   -webkit-mask-image: 
     linear-gradient(90deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%),
@@ -33,18 +33,18 @@ footer {
   background-image: none !important;
 }
 
-/* lb-Actions-Panel-Transparency */
+/* lb-Actions Panel Transparency */
 .actions-panel ul li {
 	background: transparent !important;
 	background-color: transparent !important;
 }
 
-/* lb-Actions-Panel-Borders */
+/* lb-Actions Panel Borders */
 .actions-panel ul li {
 	border: none !important;
 }
 
-/* lb-Hide-Watch-Panel */
+/* lb-Hide Watch Panel */
 .watch-panel {
 	display: none !important;
 }

--- a/websites/letterboxd.com.css
+++ b/websites/letterboxd.com.css
@@ -1,5 +1,5 @@
 /* lb-Transparency */
-body, .site-body, footer {
+body, .site-body, footer, .journal-header, .journal-page-header, .page-body, .journal-page-section.latest-articles .article-summary-grid.-medium::before, .journal-page-section.home-feature, body.editorial .page-bg {
   background: transparent !important;
 }
 .backdropped .site-header .site-header-bg {

--- a/websites/letterboxd.com.css
+++ b/websites/letterboxd.com.css
@@ -1,5 +1,5 @@
 /* lb-Transparency */
-body, .site-body, footer, .journal-header, .journal-page-header, .page-body, .journal-page-section.latest-articles .article-summary-grid.-medium::before, .journal-page-section.home-feature, body.editorial .page-bg {
+body, .site-body, footer, .journal-header, .journal-page-header, .page-body, .journal-page-section.latest-articles .article-summary-grid.-medium::before, .journal-page-section.home-feature, body.editorial .page-bg, .journal-page-header + .article-hero::before {
   background: transparent !important;
 }
 .backdropped .site-header .site-header-bg {


### PR DESCRIPTION
Hey, just a small fix because the comments had improper naming which caused this:
![Screenshot 2025-03-08 090900](https://github.com/user-attachments/assets/342550e0-8b11-4a0e-8810-894b5bac3db4)
and additional support for transparency.