### PR TITLE
Better image fade in letterboxd.com.css

### DIFF
--- a/websites/letterboxd.com.css
+++ b/websites/letterboxd.com.css
@@ -19,14 +19,14 @@ footer {
 /* lb-Fade Background Image */ 
 .backdropimage {
   -webkit-mask-image: 
-    linear-gradient(90deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%),
-    linear-gradient(180deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%),
-    linear-gradient(270deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%) !important;
+    linear-gradient(90deg,rgba(0,0,0,1) 75%, rgba(0,0,0,0) 99%),
+    linear-gradient(180deg,rgba(0,0,0,1) 60%, rgba(0,0,0,0) 70%),
+    linear-gradient(270deg,rgba(0,0,0,1) 75%, rgba(0,0,0,0) 99%) !important;
   -webkit-mask-composite: intersect !important;
-  mask-image: 
-    linear-gradient(90deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%),
-    linear-gradient(180deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%),
-    linear-gradient(270deg,rgba(0,0,0,1) 50%, rgba(0,0,0,0) 95%) !important;
+ mask-image: 
+    linear-gradient(90deg,rgba(0,0,0,1) 75%, rgba(0,0,0,0) 99%),
+    linear-gradient(180deg,rgba(0,0,0,1) 60%, rgba(0,0,0,0) 70%),
+    linear-gradient(270deg,rgba(0,0,0,1) 75%, rgba(0,0,0,0) 99%) !important;
   mask-composite: intersect !important;
 }
 .backdrop-wrapper .backdropmask::before {


### PR DESCRIPTION
Hey, I apologize for the number of pull requests today, just wanted to improve the image fading in letterboxd.
Before:
![Screenshot 2025-03-08 195742](https://github.com/user-attachments/assets/8b115a92-39b7-4bfa-a99d-3a1fa74cdc0c)
After:
![Screenshot 2025-03-08 195728](https://github.com/user-attachments/assets/e20b60fb-f076-4480-959f-a73ae7f7c53d)
