### PR TITLE
Proton mail Support

### DIFF
--- a/styles.json
+++ b/styles.json
@@ -1147,6 +1147,12 @@
     "theverge.com.css": {
       "transparency": "html, body, nav, header, .app-root, #pass-sidebar, #main, #content, section, .duet--page-layout--homepage, .fv9mhf6, .fv9mhf3, .duet--layout--river-container, .bi882e5, .duet--page-layout--post, .duet--layout--entry-body-container{\n  background-color: transparent !important;\n  background: none !important;\n  border: none !important;\n  box-shadow: none !important;\n  transition: background-color 0.5s ease-in-out, background 0.5s ease-in-out, border 0.5s ease-in-out, box-shadow 0.5s ease-in-out !important;\n}",
       "darkreader": ":root{\n  --darkreader-background-ffffff: transparent !important;\n}"
+    },
+    "mail.proton.me.css": {
+      "protonmail-Transparency": ".sidebar, .header, body, .items-column-list, .content, .main, .drawer-sidebar,\n.searchbox, .input,\n.toolbar, .items-column-list-container, .checkbox-fakecheck, .toolbar .select-all-wrapper:hover,\n.item-container-wrapper, .item-container,\n.button-promotion,\n.message-header, .button-group, .button-group-item,\n.message-attachments, .message-attachmentList-item,\n.ui-prominent, .ui-standard,\n.field, .toggle-container.toggle-container, .button-outline-weak {\n  background: transparent !important;\n}",
+      "protonmail-Disable Borders": ".input, .toolbar, .item-container, .main, .main-area-border, .message-container, .vr {\n  border: none !important;\n}",
+      "protonmail-White Borders": ".input, .main, .main-area-border, .message-attachmentList-item, .message-container {\n  border-color: white !important;\n}\n.toolbar, .item-container, .vr {\n  border: none !important;\n}",
+      "protonmail-Light Themes Support": ":root, .ui-standard, .ui-prominent {\n  --text-norm: white !important;\n  --text-weak: #cccccc !important;\n  --optional-email-item-read-text-color: #cccccc !important;\n}\n.drawer-app, .drawer-app .button-outline-weak, body .drawer-app, .drawer-app-header-actions, .apps-dropdown-app-name {\n  color: black !important;\n}\n.bg-weak {\n  background: transparent !important;\n}"
     }
   }
 }

--- a/styles.json
+++ b/styles.json
@@ -1147,12 +1147,6 @@
     "theverge.com.css": {
       "transparency": "html, body, nav, header, .app-root, #pass-sidebar, #main, #content, section, .duet--page-layout--homepage, .fv9mhf6, .fv9mhf3, .duet--layout--river-container, .bi882e5, .duet--page-layout--post, .duet--layout--entry-body-container{\n  background-color: transparent !important;\n  background: none !important;\n  border: none !important;\n  box-shadow: none !important;\n  transition: background-color 0.5s ease-in-out, background 0.5s ease-in-out, border 0.5s ease-in-out, box-shadow 0.5s ease-in-out !important;\n}",
       "darkreader": ":root{\n  --darkreader-background-ffffff: transparent !important;\n}"
-    },
-    "mail.proton.me.css": {
-      "protonmail-Transparency": ".sidebar, .header, body, .items-column-list, .content, .main, .drawer-sidebar,\n.searchbox, .input,\n.toolbar, .items-column-list-container, .checkbox-fakecheck, .toolbar .select-all-wrapper:hover,\n.item-container-wrapper, .item-container,\n.button-promotion,\n.message-header, .button-group, .button-group-item,\n.message-attachments, .message-attachmentList-item,\n.ui-prominent, .ui-standard,\n.field, .toggle-container.toggle-container, .button-outline-weak {\n  background: transparent !important;\n}",
-      "protonmail-Disable Borders": ".input, .toolbar, .item-container, .main, .main-area-border, .message-container, .vr {\n  border: none !important;\n}",
-      "protonmail-White Borders": ".input, .main, .main-area-border, .message-attachmentList-item, .message-container {\n  border-color: white !important;\n}\n.toolbar, .item-container, .vr {\n  border: none !important;\n}",
-      "protonmail-Light Themes Support": ":root, .ui-standard, .ui-prominent {\n  --text-norm: white !important;\n  --text-weak: #cccccc !important;\n  --optional-email-item-read-text-color: #cccccc !important;\n}\n.drawer-app, .drawer-app .button-outline-weak, body .drawer-app, .drawer-app-header-actions, .apps-dropdown-app-name {\n  color: black !important;\n}\n.bg-weak {\n  background: transparent !important;\n}"
     }
   }
 }

--- a/websites/mail.proton.me.css
+++ b/websites/mail.proton.me.css
@@ -4,34 +4,36 @@
 .toolbar, .items-column-list-container, .checkbox-fakecheck, .toolbar .select-all-wrapper:hover,
 .item-container-wrapper, .item-container,
 .button-promotion,
-.message-header, .button-group, .button-group-item,
+.message-header, .button-group, .button-group-item, .banner,
+.message-content,
 .message-attachments, .message-attachmentList-item,
 .ui-prominent, .ui-standard,
+.your-plan-section-container div ul li, .plan-selection div ul li,
 .field, .toggle-container.toggle-container, .button-outline-weak {
   background: transparent !important;
+}
+:root {
+  color-scheme: light dark;
 }
 
 /* protonmail-Disable Borders */
 .input, .toolbar, .item-container, .main, .main-area-border, .message-container, .vr {
-  border: none !important;
+  border: none !important; 
 }
 
 /* protonmail-White Borders */ 
 .input, .main, .main-area-border, .message-attachmentList-item, .message-container {
-  border-color: white !important;
+  border-color: light-dark(black, white) !important;
 }
 .toolbar, .item-container, .vr {
   border: none !important;
 }
 
 /* protonmail-Light Themes Support */
-:root, .ui-standard, .ui-prominent {
-  --text-norm: white !important;
-  --text-weak: #cccccc !important;
-  --optional-email-item-read-text-color: #cccccc !important;
-}
-.drawer-app, .drawer-app .button-outline-weak, body .drawer-app, .drawer-app-header-actions, .apps-dropdown-app-name {
-  color: black !important;
+.ui-standard, .ui-prominent {
+  --text-norm: light-dark(black, white) !important;
+  --text-weak: light-dark(#333333,#cccccc) !important;
+  --optional-email-item-read-text-color: light-dark(#333333,#cccccc) !important;
 }
 .bg-weak {
   background: transparent !important;

--- a/websites/mail.proton.me.css
+++ b/websites/mail.proton.me.css
@@ -17,12 +17,12 @@
 }
 
 /* protonmail-Disable Borders */
-.input, .toolbar, .item-container, .main, .main-area-border, .message-container, .vr {
+.input, .toolbar, .item-container, .main, .main-area-border, .message-container, .vr, .button-group, .message-attachmentList-item, .banner {
   border: none !important; 
 }
 
 /* protonmail-Switch Border Color */ 
-.input, .main, .main-area-border, .message-attachmentList-item, .message-container {
+.input, .main, .main-area-border, .message-attachmentList-item, .message-container, .button-group, .banner {
   border-color: light-dark(black, white) !important;
 }
 .toolbar, .item-container, .vr {

--- a/websites/mail.proton.me.css
+++ b/websites/mail.proton.me.css
@@ -21,7 +21,7 @@
   border: none !important; 
 }
 
-/* protonmail-White Borders */ 
+/* protonmail-Switch Border Color */ 
 .input, .main, .main-area-border, .message-attachmentList-item, .message-container {
   border-color: light-dark(black, white) !important;
 }
@@ -29,7 +29,7 @@
   border: none !important;
 }
 
-/* protonmail-Light Themes Support */
+/* protonmail-Themes Support */
 .ui-standard, .ui-prominent {
   --text-norm: light-dark(black, white) !important;
   --text-weak: light-dark(#333333,#cccccc) !important;

--- a/websites/mail.proton.me.css
+++ b/websites/mail.proton.me.css
@@ -1,0 +1,38 @@
+/* protonmail-Transparency */
+.sidebar, .header, body, .items-column-list, .content, .main, .drawer-sidebar,
+.searchbox, .input,
+.toolbar, .items-column-list-container, .checkbox-fakecheck, .toolbar .select-all-wrapper:hover,
+.item-container-wrapper, .item-container,
+.button-promotion,
+.message-header, .button-group, .button-group-item,
+.message-attachments, .message-attachmentList-item,
+.ui-prominent, .ui-standard,
+.field, .toggle-container.toggle-container, .button-outline-weak {
+  background: transparent !important;
+}
+
+/* protonmail-Disable Borders */
+.input, .toolbar, .item-container, .main, .main-area-border, .message-container, .vr {
+  border: none !important;
+}
+
+/* protonmail-White Borders */ 
+.input, .main, .main-area-border, .message-attachmentList-item, .message-container {
+  border-color: white !important;
+}
+.toolbar, .item-container, .vr {
+  border: none !important;
+}
+
+/* protonmail-Light Themes Support */
+:root, .ui-standard, .ui-prominent {
+  --text-norm: white !important;
+  --text-weak: #cccccc !important;
+  --optional-email-item-read-text-color: #cccccc !important;
+}
+.drawer-app, .drawer-app .button-outline-weak, body .drawer-app, .drawer-app-header-actions, .apps-dropdown-app-name {
+  color: black !important;
+}
+.bg-weak {
+  background: transparent !important;
+}


### PR DESCRIPTION
Added mail.proton.me with Transparency and Light Themes Support along with some border options.
Issue: #41 
Light Theme:
![Screenshot 2025-03-16 162515](https://github.com/user-attachments/assets/f0bbb418-8951-4d53-a19a-816c6a70b5ed)
Dark Theme:
![Screenshot 2025-03-16 162539](https://github.com/user-attachments/assets/b72e3c8e-7253-44d6-a5d8-ba820f6dd50b)
 