### PR TITLE
Add support for dropbox.com

### DIFF
--- a/websites/dropbox.com.css
+++ b/websites/dropbox.com.css
@@ -1,0 +1,19 @@
+/* transparency */
+html,
+body,
+.dig-Theme-vis2023--bright,
+.dig-Theme-vis2023--dark {
+  --dig-color__background__subtle: transparent !important;
+  --dig-color__background__base: transparent !important;
+
+  background-color: transparent !important;
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+  transition: background-color 0.5s ease-in-out, background 0.5s ease-in-out,
+    border 0.5s ease-in-out, box-shadow 0.5s ease-in-out !important;
+}
+/* darkreader */
+:root {
+  --darkreader-background-ffffff: transparent !important;
+}


### PR DESCRIPTION
Hello,
I’ve added support for the dropbox.com website. This is my very first contribution, and I hope I did everything correctly.
Please note that this theme does not support Dropbox Paper.
![image](https://github.com/user-attachments/assets/1dcba423-a7f4-4cec-8de3-4f2d97daa004)
