### PR TITLE
whatsapp: improved transaprency

### DIFF
--- a/websites/web.whatsapp.com.css
+++ b/websites/web.whatsapp.com.css
@@ -6,7 +6,7 @@ nav,
 .nav,
 navbar, .x15g3fpr,
 .navbar, ._al_c,
-#navbar, .x1280gxy, .xsm26vf,
+#navbar, .xsm26vf,
 header, [aria-label="Community tab drawer"] > div,
 #header, .x1n2onr6 ._ak72:not(:hover),
 .header,
@@ -22,16 +22,28 @@ section, .two::after,
 #__next, #side, #side > div, #side > div > div, .xsknx04,
 #navigation-wrapper,
 #global-navbar,
-.head.notfixed, 
+.head.notfixed,
 body[data-theme="dark"], body[data-theme="light"],
 body.dark_mode, body.light_mode,
 footer > div:first-of-type,
-#app > div:first-of-type::after {
+#app > div:first-of-type::after,
+._alzb, ._ak73 *, ._ak73::after, ._alzb::before
+header, .three , .x1bmpntp,
+.x1280gxy span > div:not([aria-label="Image"]) {
   background-color: transparent !important;
   background: none !important;
   border: none !important;
   box-shadow: none !important;
   transition: background-color 0.5s ease-in-out, background 0.5s ease-in-out, border 0.5s ease-in-out, box-shadow 0.5s ease-in-out !important;
+}
+
+.x1280gxy, ._ak73:hover, ._alzb:hover {
+  background: rgba(0, 0,0 , .1) !important;
+  background-color: rgba(0, 0,0 , .1) !important;
+}
+
+.x1setqd9::after {
+  display: none;
 }
 
 :root, .dark {
@@ -41,10 +53,10 @@ footer > div:first-of-type,
   --conversation-header-border: transparent !important;
 }
 
-body:has([aria-label="Status tab drawer"], [aria-label="Channel tab drawer"], [aria-label="Community tab drawer"], [title="Settings"], [title="Profile"]) ._aigw{ 
-  header:has([aria-label="WhatsApp"]), #side{
-  display: none !important;
-}
+body:has([aria-label="Status tab drawer"], [aria-label="Channel tab drawer"], [aria-label="Community tab drawer"], [title="Settings"], [title="Profile"]) ._aigw{
+  header:has([aria-label="WhatsApp"]), #side {
+    display: none !important;
+  }
 }
 
 /* wa-layout fixes */


### PR DESCRIPTION
Addresses #1188

1. Translucent profile info menu
2. Transparent Selected message (when replying)
3. Translucent chat list item on hover
4. Transparent top bar when profile info menu is open

> [!IMPORTANT]
> I have used some class names which might change in the future. But similar usage was already found.