### PR TITLE
dropbox theme fix

### DIFF
--- a/websites/dropbox.com.css
+++ b/websites/dropbox.com.css
@@ -3,6 +3,15 @@ html,
 body,
 .dig-Theme-vis2023--bright,
 .dig-Theme-vis2023--dark,
+._sidebar-background_1cajl_17,
+._sc-comment-stream-editor_12v0k_171
+  ._sc-comment-editor-focus-container_12v0k_199,
+._crop-details-light_12mja_8,
+._toolbar-holder_4tpnk_4,
+._upscale-light_160y1_10,
+._adjust-light_1ah3m_36,
+._filter-row_7x6z1_20,
+.folder-history-event-header.folder-history-event-header--right-rail,
 ._sidebar_x74gj_1 {
   --dig-color__background__subtle: transparent !important;
   --dig-color__background__base: transparent !important;
@@ -17,8 +26,13 @@ body,
 .dig-Theme--dark {
   --color__standard__background: transparent !important;
 }
-.dig-5lbgm3o_22-1-0 {
+.dig-5lbgm3o_22-1-0,
+.dig-5lbgm3o_22-2-1,
+.copy-link-mini-modal__overlay {
   background-color: var(--dig-color__background__raised) !important;
+}
+._titleBarWrapper_10wwt_31 {
+  --dig-color__background__raised: transparent !important;
 }
 /* darkreader */
 :root {


### PR DESCRIPTION
Following issue #1313, I redesigned the popup for creating a folder, which was previously unreadable. I also made some specific menus, like the photo editing one, transparent. I've continued checking things here and there, but since there are so many windows and hidden menus, there might still be a few issues. That said, I’ve made broader changes to help ensure there are no more readability bugs related to transparency. For example, I found a bug in the 'Business' menu, which doesn’t support dark mode—making the text hard to read.
If I have time after my exams, I might make a version without variables just to be sure, but the version I shared seems correct to me