### PR TITLE
Add CSS style for check.torproject.org

### DIFF
--- a/websites/check.torproject.org.css
+++ b/websites/check.torproject.org.css
@@ -1,0 +1,29 @@
+/* transparency */
+body,
+.head {
+  color: white !important;
+  background-color: transparent !important;
+}
+
+/* anchor styles */
+a {
+  color: white !important;
+  text-decoration: none !important;
+  transition: color 0.3s ease !important;
+}
+
+/* anchor hover */
+a:not(#donate):hover {
+    color: #85559f !important;
+    text-decoration: underline !important;
+}
+
+/* no javascript text */
+p#js {
+  display: none !important;
+}
+
+/* no footer */
+div.foot {
+  display: none !important;
+}


### PR DESCRIPTION
I added styles to check.torproject.org to improve readability and clean up the layout. My changes include:

- Made body and .head transparent with white text for better contrast.

- Styled all links as white with a smooth hover effect, while excluding the donate button.

- Hid the JavaScript message and the footer to declutter the page.