### PR TITLE
Add support for 9to5Mac.com

### DIFF
--- a/websites/9to5mac.com.css
+++ b/websites/9to5mac.com.css
@@ -15,7 +15,7 @@ body, .header-bottom {
     text-shadow: 0 0 4px black, 0 0 8px black;
 }
 
-/* header glass effect */
+/* show header on hover */
 .site-header {
   transition: opacity 0.3s ease-in-out !important;
   opacity: 0 !important;

--- a/websites/9to5mac.com.css
+++ b/websites/9to5mac.com.css
@@ -1,0 +1,25 @@
+/* transparency */
+body, .header-bottom {
+    background-color: transparent !important;
+}
+
+/* submenu glass effect */
+.sub-menu {
+    background-color: transparent !important;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 16px;
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.3); 
+    text-shadow: 0 0 4px black, 0 0 8px black;
+}
+
+/* header glass effect */
+.site-header {
+  transition: opacity 0.3s ease-in-out !important;
+  opacity: 0 !important;
+  &:hover {
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
Fixes #1916. I've added:
- Transparency support
- Glass effect for submenu
- Shows header on hover, and hides it when not hovered with a fade animation