### PR TITLE
Google Calendar - Added glass background to event details edit page

### DIFF
--- a/websites/calendar.google.com.css
+++ b/websites/calendar.google.com.css
@@ -85,6 +85,13 @@ li.F262Ye,
   background-color: var(--gm3-sys-color-background) !important;
 }
 
+.K4vxLd-WsjYwc {
+   background-color: #18181860 !important;
+   border: solid !important;
+   border-width: 1px !important;
+   border-color: #ffffff30 !important;
+}
+
 /* transparent settings */
 .MDfQ7 {
   padding-top: 20px !important;


### PR DESCRIPTION
Before:
<img width="1105" height="719" alt="Screenshot from 2025-10-13 12-57-35" src="https://github.com/user-attachments/assets/cbcbbe15-86dc-4427-af2b-5c7b353ebe30" />


After:
<img width="1105" height="719" alt="Screenshot from 2025-10-13 12-57-18" src="https://github.com/user-attachments/assets/5fcac068-0127-4e4c-a71f-52399b2f1ee4" />

