### PR TITLE
fix(ytm): exclude saved to playlist toast from "hide elements" setting

### DIFF
--- a/websites/music.youtube.com.css
+++ b/websites/music.youtube.com.css
@@ -32,8 +32,7 @@ ytmusic-app[is-bauhaus-sidenav-enabled] #guide-wrapper.ytmusic-app {
 
 /* Hide elements */
 #nav-bar-divider,
-#browse-page > #background,
-tp-yt-paper-toast.toast-button.style-scope.yt-notification-action-renderer.paper-toast-open {
+#browse-page > #background {
   display: none !important;
 }
 


### PR DESCRIPTION
In YouTube Music, when you click "save to playlist" for a song then it is automatically added to the playlist where you most recently added a song. To change the playlist you need to click on the "Change" button which appears in the toast which says "Added to xx" playlist.  

<img width="296" height="59" alt="image" src="https://github.com/user-attachments/assets/ccf1c35d-a32d-43f4-b2b2-e57d45d0b0cf" />

This toast is hidden with the "Hide elements" setting. Removed this toast from elements affected by hide elements setting. 