### PR TITLE
fix: yt caption backgroup

### DIFF
--- a/websites/youtube.com.css
+++ b/websites/youtube.com.css
@@ -410,6 +410,10 @@ ytd-two-column-browse-results-renderer:has(.ytd-playlist-video-renderer) {
   width: fit-content !important;
 }
 
+.ytp-caption-segment {
+  background: none !important;
+}
+
 /* yt-Keep player shadow $ Remove the shadow around the player when disabled */
 .ytp-gradient-bottom {
   display: initial !important;


### PR DESCRIPTION
This's been bothering me for a while so I decided to see how hard it'd be to fix. Answer: sub-1-min PR 🥳

Top: new, old: bottom

<img width="296" height="51" alt="Screenshot 2025-11-01 at 7 26 01 PM" src="https://github.com/user-attachments/assets/9c51ac62-18ca-4d00-9f21-69b4b103bdda" />
