### PR TITLE
Update music.youtube.com.css

### DIFF
--- a/websites/music.youtube.com.css
+++ b/websites/music.youtube.com.css
@@ -94,6 +94,10 @@ ytmusic-chip-cloud-renderer.style-scope.ytmusic-section-list-renderer:hover {
   min-width: auto !important;
 }
 
+div.ytmusic-player-queue#contents {
+  margin-bottom: 0 !important; /* @ margin no longer needed as sidebar is above player */
+}
+
 /* Centered player */
 ytmusic-app-layout:not([player-ui-state="FULLSCREEN"]) #main-panel {
   position: absolute !important;
@@ -128,6 +132,16 @@ ytmusic-nav-bar,
   top: 0 !important;
   height: 100% !important;
   width: 100% !important;
+}
+
+/* @ fix overlapping of nav bar and guide */
+.content {
+	--ytmusic-player-page-vertical-padding: var(--ytmusic-nav-bar-height); 
+	--ytmusic-player-page-horizontal-padding: calc(var(--ytmusic-guide-width) + 20px);
+}
+
+div.ytmusic-player-queue#contents {
+  margin-bottom: calc(var(--ytmusic-player-bar-height) + 10px); /* @ otherwise user can't reach the final song of the queue as its covered by player bar */
 }
 
 /* Player bar styling */


### PR DESCRIPTION
Decided to fix some annoyances with the current styling for music.youtube.com

Added features

- fixed overlap nav bar and "guide" when using nav background
- made content fill 100% of viewport height again (previously bottom margin was forced which shrinked the viewport vertically)

This is my second time contributing to an open source project so feedback is appreciated.

Screenshots:

<img width="1358" height="1086" alt="Bildschirmfoto vom 2025-11-05 21-33-03" src="https://github.com/user-attachments/assets/27ecbdaf-3be4-4388-b68a-447cd071a8a9" />
<img width="1358" height="1086" alt="Bildschirmfoto vom 2025-11-05 21-31-50" src="https://github.com/user-attachments/assets/83ef3adb-391a-4ac4-a32c-cd1186aa7d31" />
