### PR TITLE
fix: github reaction outlines

### DIFF
--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -387,7 +387,7 @@ body:has(header > .search-expanded) .application-main {
 }
 
 /* gh-remove borders */
-.prc-Button-ButtonBase-c50BI,
+.prc-Button-ButtonBase-c50BI:not(.ReactionButton-module__reactionToggleButtonReacted--TgLue),
 .BtnGroup-item,
 .Button--secondary,
 .TextInput__StyledTextInput-sc-ttxlvl-0,


### PR DESCRIPTION
Before:

<img width="87" height="46" alt="Screenshot 2025-11-10 at 7 14 47 PM" src="https://github.com/user-attachments/assets/789d4770-fc82-4780-8b58-41a82a6a538c" />

After:

<img width="87" height="46" alt="Screenshot 2025-11-10 at 7 15 40 PM" src="https://github.com/user-attachments/assets/37d42ae0-f12d-45d8-aeaa-a7b9c2af92a2" />
