### PR TITLE
fix(github.com): comment button background & green buttons

### DIFF
--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -48,11 +48,7 @@ section[aria-label="Events"] > div > div > [data-timeline-event-id] {
   background: none !important;
   border: none !important;
   box-shadow: none !important;
-  transition:
-    background-color 0.5s ease-in-out,
-    background 0.5s ease-in-out,
-    border 0.5s ease-in-out,
-    box-shadow 0.5s ease-in-out !important;
+  transition: background-color 0.5s ease-in-out, background 0.5s ease-in-out, border 0.5s ease-in-out, box-shadow 0.5s ease-in-out !important;
 }
 
 button[role="tab"] {
@@ -161,7 +157,7 @@ details-dialog.Box,
 }
 
 /* gh-glass effect */
-.prc-Button-ButtonBase-c50BI,
+.prc-Button-ButtonBase-c50BI:not(.Toolbar-module__group--dOhAD > button[data-component="IconButton"], button[data-component="IconButton"].ToolbarButton-module__iconButton--o0jFl),
 .MergeabilityIcon-module__mergeabilityIcon--GOu7M,
 .range-editor,
 .TableHead.prc-DataTable-TableHead-eOrJU,
@@ -254,17 +250,13 @@ button[aria-label="Search this repository"],
 .btn.btn-block.js-profile-editable-edit-button,
 .btn.js-quick-submit-alternative,
 #your-repos-filter {
-  box-shadow:
-    rgba(0, 0, 0, 0.05) 0px -36px 30px 0px inset,
-    rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset !important;
+  box-shadow: rgba(0, 0, 0, 0.05) 0px -36px 30px 0px inset, rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset !important;
   background-color: light-dark(#fff8, #0005) !important;
   border-radius: 0.5em !important;
 }
 
 .avatar-upload div.position-absolute {
-  box-shadow:
-    rgba(0, 0, 0, 0.5) 0px -36px 30px 0px inset,
-    rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset !important;
+  box-shadow: rgba(0, 0, 0, 0.5) 0px -36px 30px 0px inset, rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset !important;
 }
 
 .TabNav__TabNavTabList-sc-pwdi4r-1.DvNYj,
@@ -292,9 +284,7 @@ button[aria-label="Search this repository"],
 }
 
 .timeline-comment-group .timeline-comment {
-  box-shadow:
-    rgba(0, 0, 0, 0.05) 0px -36px 30px 0px inset,
-    rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset !important;
+  box-shadow: rgba(0, 0, 0, 0.05) 0px -36px 30px 0px inset, rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset !important;
   background-color: light-dark(#fff8, #0005) !important;
   border-radius: 0.5em !important;
 }

--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -157,7 +157,11 @@ details-dialog.Box,
 }
 
 /* gh-glass effect */
-.prc-Button-ButtonBase-c50BI:not(.Toolbar-module__group--dOhAD > button[data-component="IconButton"], button[data-component="IconButton"].ToolbarButton-module__iconButton--o0jFl),
+.prc-Button-ButtonBase-c50BI:not(
+    [data-variant="primary"],
+    .Toolbar-module__group--dOhAD > button[data-component="IconButton"],
+    button[data-component="IconButton"].ToolbarButton-module__iconButton--o0jFl
+  ),
 .MergeabilityIcon-module__mergeabilityIcon--GOu7M,
 .range-editor,
 .TableHead.prc-DataTable-TableHead-eOrJU,


### PR DESCRIPTION
Old comment button background:
<img width="396" height="40" alt="Screenshot 2025-11-20 at 8 52 05 AM" src="https://github.com/user-attachments/assets/f253bb77-9de0-4ac7-adac-19c30e766a31" />


New comment button background:
<img width="376" height="31" alt="Screenshot 2025-11-20 at 8 46 12 AM" src="https://github.com/user-attachments/assets/32c1c2af-a83d-4e96-a758-b2d6646fce37" />

Green buttons:
<img width="172" height="40" alt="Screenshot 2025-11-20 at 8 46 36 AM" src="https://github.com/user-attachments/assets/315472be-93d2-4049-b79f-620f032b0ba2" />
