### PR TITLE
Added support for knowledgeboat.com

### DIFF
--- a/websites/knowledgeboat.com.css
+++ b/websites/knowledgeboat.com.css
@@ -1,23 +1,34 @@
 :root {
-    --darkreader-background-eeeeee: transparent;
-    --darkreader-background-ffffff: transparent;
+  --darkreader-background-eeeeee: transparent;
+  --darkreader-background-ffffff: transparent;
 }
- body, html, .jss1, .jss2, .jss53, .jss4, .jss42, nav, .jss8, .jss59, .jss3, .jss122 {
-    background: none !important
+body,
+html,
+.jss1,
+.jss2,
+.jss53,
+.jss4,
+.jss42,
+nav,
+.jss8,
+.jss59,
+.jss3,
+.jss122 {
+  background: none !important;
 }
 
 header {
-    backdrop-filter: blur(50px) !important;
-    background: #00000060 !important;
+  backdrop-filter: blur(50px) !important;
+  background: #00000060 !important;
 }
 
 .jss95 {
-    z-index: 10000;
-    backdrop-filter: blur(64px) !important;
-    background: #00000060 !important;
+  z-index: 10000;
+  backdrop-filter: blur(64px) !important;
+  background: #00000060 !important;
 }
 
 .jss120 {
-    backdrop-filter: blur(256px) !important;
-    background: #00000090
+  backdrop-filter: blur(256px) !important;
+  background: #00000090;
 }


### PR DESCRIPTION
<img width="1614" height="969" alt="image" src="https://github.com/user-attachments/assets/ac26e190-b0a1-4b0f-80d8-f02522ef0067" /> (Without darkreader)



<img width="1622" height="973" alt="image" src="https://github.com/user-attachments/assets/ad8712c2-3198-4092-90f0-d43bcf317f99" />
(With Darkreader)
