### PR TITLE
Added theme for Quill.org

### DIFF
--- a/websites/quill.org.css
+++ b/websites/quill.org.css
@@ -1,0 +1,70 @@
+/* transparency */
+html,
+body,
+nav,
+#nav,
+.nav, .sticky-category-bar-container,
+navbar, body > .root-l-content, .p-archiveBody__container,
+.navbar, .page_wrapper.without-image,
+#navbar, header > .global-head-cont,
+header, .toc-sidebar,
+#header, #temp_banner, .ranavnode,
+.header, header::before, body > article,
+app, #root > div > div > .w-full,
+#app, footer, .sc-tvx700-7.egPRoP,
+.sidebar-wrap, .p-sectionLinks,
+section, .main, main::before,
+#__next, .sidebar-wrapper, .sidebar-footer-wrapper, .sidebar-footer-container::before,
+#root, .min-h-screen.bg-white,
+.app, .AppContainer,
+.app-root, #wrapper, /* @Testing inline comments in selectors */
+body[data-theme="dark"], body[data-theme="light"],
+#pass-sidebar, .side-bar,
+#main, .sidebar, .global-content__content,
+main, .header-top,  /* any comment */
+#content, #cu-identity,
+section, .l-root,
+#__next, .landing-hero,
+#navigation-wrapper,
+#global-navbar, .layout__content-wrapper,
+.head.notfixed, .main-container,
+#app > div, .btm-nav > a, .oc-content--main,
+body.dark_mode, body.light_mode,
+text-div > textarea, #starlight__sidebar, .sidebar-pane, .page--article, #xf-guide,
+[data-color-theme] body, #__next > div, .hero-right, #middle, .HeaderLinks_header__Ia2QY, #page-content, section[data-role], .activity-container {
+  background-color: transparent !important;
+  background: none !important;
+  border: none !important; /* any comment */
+  box-shadow: none !important;
+  transition:
+    background-color 0.5s ease-in-out,
+    background 0.5s ease-in-out,
+    border 0.5s ease-in-out,
+    box-shadow 0.5s ease-in-out !important;
+  /* any comment */
+  /* any comment */
+}
+
+/* darkreader */
+:root {
+  --darkreader-background-ffffff: transparent !important;
+}
+
+@layer {
+  :root,
+  html,
+  body {
+    --darkreader-background-ffffff: transparent !important;
+    background-color: transparent !important;
+  }
+}
+
+/* no footer */
+footer,
+#Footer,
+.Footer,
+mfe-footer-pharos-footer,
+.footer,
+#footer {
+  display: none !important;
+}


### PR DESCRIPTION
This just adds transparency for the activity page. Everything else seems to be handled automatically using Dark Reader.

## Before
<img width="1656" height="1035" alt="image" src="https://github.com/user-attachments/assets/d0798633-c773-4323-80a3-2ad4f3adc881" />

## After
<img width="1635" height="1029" alt="image" src="https://github.com/user-attachments/assets/36b68bc6-4d0a-458e-bf3a-903c09fcc023" />
