### PR TITLE
Remove obsolete sidebar transparency due to WA Web layout redesign

### DIFF
--- a/websites/web.whatsapp.com.css
+++ b/websites/web.whatsapp.com.css
@@ -45,10 +45,6 @@ body,
   }
 }
 
-._aigs:has(._aigw > div > span > div) .x18pi947 {
-  opacity: 0 !important;
-}
-
 /* wa-Immersive Popup */
 .x1akjpcp,
 .xbyyjgo,


### PR DESCRIPTION
WhatsApp Web has updated its UI structure, changing how the chat list and message view are arranged. The chat list no longer sits below messages or obstructs the view in a way that requires hiding it.

This commit removes the legacy rule that made the sidebar transparent (invisible) when a chat is open.

Resolves the following issues: Closes #2348 Closes #2331 Closes #2330 Closes #2146 Closes #2090 Closes #2053