### PR TITLE
Change text color from black to whitesmoke in news.ycombinator CSS

### DIFF
--- a/websites/news.ycombinator.com.css
+++ b/websites/news.ycombinator.com.css
@@ -1,10 +1,11 @@
 /* ycom-transparency */
 :root {
   --darkreader-background-ffffff: transparent !important;
+  color-scheme: light dark;
 }
 table {
   background-color: transparent !important;
 }
 .commtext, .c00 a:link, a:link {
-  color: whitesmoke;
+  color: light-dark(#000, whitesmoke);
 }


### PR DESCRIPTION
Transparency did not update the black text color of the website.

This PR updates the text color to whitesmoke, so text can be visible.

Happy to make any changes you may want. 