### PR TITLE
fix: add missing transparency var for search.brave.com (#2356)

### DIFF
--- a/websites/search.brave.com.css
+++ b/websites/search.brave.com.css
@@ -1,6 +1,7 @@
 /* brave-transparency */
 :root {
   --color-page-background: transparent !important;
+  --color-search-background-page: transparent !important;
 }
 
 body.fullscreen-drawer-open,


### PR DESCRIPTION
Before:
<img width="1868" height="1194" alt="16-20-01_LOQl2XtP3P0W" src="https://github.com/user-attachments/assets/207b456f-31b0-4a44-a55d-e6e4cb86abf5" />

After:
<img width="1815" height="1147" alt="image" src="https://github.com/user-attachments/assets/231bb1ac-d044-4ae0-921b-57adb3f4864e" />
