### PR TITLE
feat: add read.readwise.io transparency theme

### DIFF
--- a/websites/read.readwise.io.css
+++ b/websites/read.readwise.io.css
@@ -1,0 +1,64 @@
+/* rw-transparency $ Make all background surfaces transparent */
+
+html,
+body,
+aside,
+main,
+header,
+nav,
+section,
+article,
+div,
+button,
+a,
+input,
+span,
+li {
+  background-color: transparent !important;
+}
+
+/* rw-readable $ Keep popover panels and menus readable */
+
+div[class*="_appearancePanel_"],
+div[class*="_appearancePanel_"] *,
+div[class*="_dropdownContent_"],
+div[class*="_dropdownContent_"] *,
+div[class*="_content_1j6f0"],
+div[class*="_content_1j6f0"] *,
+div.popover,
+div.popover *,
+div[class*="_commandsContainer_"],
+div[class*="_commandsContainer_"] *,
+div[class*="_paletteActionRow_"],
+div[class*="_paletteActionRow_"] *,
+div[class*="_palette_29opr"] > *,
+div[class*="_palette_29opr"] input,
+div[class*="_sortMenu_"],
+div[class*="_sortMenu_"] *,
+div[class*="_filterMenu_"],
+div[class*="_filterMenu_"] * {
+  background-color: light-dark(#eee, #1a1f25) !important;
+}
+
+/* rw-borders $ Remove borders, shadows, and dividers */
+
+div[class*="_divider_"],
+div[class*="_trashDivider_"],
+div.document-header-separator,
+span[class*="_bulletSeparator_"] {
+  border-color: transparent !important;
+}
+
+*:focus-visible {
+  outline: 2px solid light-dark(#0003, #fff3) !important;
+}
+
+/* rw-hover $ Hide sidebar toggle until hovered */
+
+[aria-label="Toggle sidebar"] {
+  opacity: 0 !important;
+  transition: opacity 0.3s ease-in-out !important;
+  &:hover {
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds full zen transparency theme for Readwise Reader (`read.readwise.io`)
- Uses element-level CSS overrides with CSS module prefix selectors for stability
- Keeps popover menus, command palette, and dropdown menus readable with opaque backgrounds
- Includes accessibility: `:focus-visible` outline restoration with `light-dark()`

Closes #930
Closes #1232

## Approach

Readwise Reader uses CSS Modules with hashed class names. Instead of targeting unstable exact classes, the theme uses:
1. **Nuclear transparency** — `background-color: transparent !important` on all common element types (`div`, `button`, `span`, etc.)
2. **Readable exceptions** — specific popover/menu containers get opaque backgrounds via higher-specificity selectors (appearance panel, dropdown content, command palette, configure popover)

This covers all views: Home, Library, Reader, and Settings.

## Testing

- Tested in Firefox with Stylus extension
- Verified dark mode (theme--dark) and light mode (theme--light)
- Verified popover readability: Aa appearance panel, Cmd+K command palette, add document menu, configure menu, sort/filter menus
- Verified keyboard navigation (focus-visible outlines)
- Verified library view, article reader, home page

## Maintenance Notes

- CSS module prefix selectors (e.g., `[class*="_sidebar_"]`) survive hash changes across deploys since the semantic prefix comes from source code
- The command palette hash `_palette_29opr` is deploy-specific and may need updating — flagged for awareness
- `light-dark()` requires Firefox 120+ / Chrome 123+