### PR TITLE
fix youtube transparent bars

### DIFF
--- a/websites/youtube.com.css
+++ b/websites/youtube.com.css
@@ -265,7 +265,6 @@ ytd-merch-shelf-renderer,
 /* yt-Transparent video background */
 .html5-main-video,
 .html5-video-container,
-#movie_player,
 #container,
 #ytd-player,
 #player-container,
@@ -274,6 +273,10 @@ ytd-merch-shelf-renderer,
 ytlr-player {
   background-color: #00000000 !important;
   background: transparent !important;
+}
+
+#movie_player {
+  background: black !important;
 }
 
 #cinematics {


### PR DESCRIPTION
Youtube videos which were not able to fill the screen would normally have black bars, but with zen internet it would have transparent bars, which could create issues with cinematic videos, like watching a dark movie with a white background, which would cause ugly white bars.
This fixes the issue by adding back the black background for the player.