### PR TITLE
fix: apply rules for url paths outside of https://www.prydwen.gg/gfl-exilium/

### DIFF
--- a/websites/prydwen.gg.css
+++ b/websites/prydwen.gg.css
@@ -12,7 +12,7 @@ section,
 .left-menu,
 .top-nav,
 .content,
-.content-background.exilium,
+.content-background,
 .left-menu-content-wrapper {
   background-color: transparent !important;
   background: none !important;


### PR DESCRIPTION
the original url has been removed but this link is still up
https://www.prydwen.gg/gfl-exilium/guides/characters-and-progression/

### comparison
before:
<img width="1874" height="1070" alt="image" src="https://github.com/user-attachments/assets/e42644ca-956b-4ea3-9fc1-3863ed26312b" />


after:
<img width="1862" height="1063" alt="image" src="https://github.com/user-attachments/assets/f789349a-e7ae-4384-a341-4c626a53b4d8" />
tested on https://www.prydwen.gg/star-rail/