### PR TITLE
Update -miruro.tv.css

### DIFF
--- a/websites/-miruro.tv.css
+++ b/websites/-miruro.tv.css
@@ -15,6 +15,7 @@ body,
 .ghhYJl {
   background-color: transparent !important;
   background: none !important;
+  --global-primary-bg: none !important;
   border: none !important;
   box-shadow: none !important;
   transition:
@@ -22,6 +23,11 @@ body,
     background 0.5s ease-in-out,
     border 0.5s ease-in-out,
     box-shadow 0.5s ease-in-out !important;
+}
+
+/* miruro-16/9 player */
+.player {
+  aspect-ratio: 16/9 !important;
 }
 
 /* miruro-no footer */


### PR DESCRIPTION
This makes two slight changes to miruro.tv style:
- Makes player container background transparent (by enforcing the value of `--global-primary-bg`)
- Makes the player use 16/9 ratio to avoid letterboxing while in theater mode (for some reason the website uses 21/9 by default, but afaik the majority of anime use 16/9) 

![Current style](https://assets.xeppelin.org/dev/miruro_before.png)
![After changes](https://assets.xeppelin.org/dev/miruro_after.png)