### PR TITLE
feat(z.ai): chat css introduced

### DIFF
--- a/websites/chat.z.ai.css
+++ b/websites/chat.z.ai.css
@@ -1,0 +1,14 @@
+/* transparency */
+.bg-\[\#f8f8f8\] {
+  background-color: transparent !important;
+}
+.bg-\[\#f9f9f9\] {
+  background-color: transparent !important;
+}
+
+/* cosmetic */
+/* text fixing colour */
+.text-gray-500, .text-gray-500\/80 {
+    color: black;
+    font-weight: bold;
+}


### PR DESCRIPTION
Adding transparent background for the z.ai web view chat 

<img width="1678" height="1021" alt="image" src="https://github.com/user-attachments/assets/decd0bd9-3f93-450d-9aee-28cb786229aa" />


*ignore the white overlay, just to hide my own chats. 

close #1746