### PR TITLE
Update contributor image URL to staging endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Custom CSS for websites to make the internet beautiful. Transparency being the m
 ## Contributors
 
 <a href="https://github.com/sameerasw/my-internet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=sameerasw/my-internet" />
+  <img src="https://stg.contrib.rocks/image?repo=sameerasw/my-internet" />
 </a>
 
 ## Contributing styles


### PR DESCRIPTION
## Because the current contributor URL no longer updates, I recommend using their latest URL.

- Reference of issue and solution: https://github.com/lacolaco/contributors-img/issues/1482