### PR TITLE
fix(gh): force repository top-bar icons & stop approximating tab text width

### DIFF
--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -323,6 +323,7 @@ nav[aria-label="Repository"] > ul > li > a {
   span[data-component="text"] {
     opacity: 0 !important;
     max-width: 0em !important;
+    overflow: hidden !important;
     transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.2) !important;
   }
   &:hover {

--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -315,6 +315,10 @@ a.rgh-own-conversation:hover {
 }
 
 /* no tab text $ Make repository tabs only got icons and show text only on hover */
+.prc-UnderlineNav-UnderlineWrapper-GWONT[data-hide-icons-breakpoint="xxlarge"] .prc-UnderlineNav-ItemsList-oj8gN [data-component="icon"] {
+  display: block !important;
+}
+
 nav[aria-label="Repository"] > ul > li > a {
   span[data-component="text"] {
     opacity: 0 !important;
@@ -323,7 +327,6 @@ nav[aria-label="Repository"] > ul > li > a {
   }
   &:hover {
     span[data-component="text"] {
-      width: 9em !important;
       opacity: 1 !important;
     }
   }

--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -322,7 +322,7 @@ a.rgh-own-conversation:hover {
 nav[aria-label="Repository"] > ul > li > a {
   span[data-component="text"] {
     transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.2) !important;
-    max-width: 20em !important;
+    max-width: 9em !important;
     overflow: hidden !important;
   }
   &:not(:hover) {

--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -321,14 +321,14 @@ a.rgh-own-conversation:hover {
 
 nav[aria-label="Repository"] > ul > li > a {
   span[data-component="text"] {
+    opacity: 0 !important;
+    max-width: 0em !important;
     transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.2) !important;
-    max-width: 9em !important;
-    overflow: hidden !important;
   }
-  &:not(:hover) {
+  &:hover {
     span[data-component="text"] {
-      opacity: 0 !important;
-      max-width: 0 !important;
+      max-width: 9em !important;
+      opacity: 1 !important;
     }
   }
 }

--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -322,11 +322,13 @@ a.rgh-own-conversation:hover {
 nav[aria-label="Repository"] > ul > li > a {
   span[data-component="text"] {
     transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.2) !important;
+    max-width: 20em !important;
+    overflow: hidden !important;
   }
   &:not(:hover) {
     span[data-component="text"] {
       opacity: 0 !important;
-      width: 0em !important;
+      max-width: 0 !important;
     }
   }
 }

--- a/websites/github.com.css
+++ b/websites/github.com.css
@@ -314,20 +314,19 @@ a.rgh-own-conversation:hover {
   padding: 0.5em !important;
 }
 
-/* no tab text $ Make repository tabs only got icons and show text only on hover */
+/* no tab text $ Make repository tabs only get icons, and show text only on hover */
 .prc-UnderlineNav-UnderlineWrapper-GWONT[data-hide-icons-breakpoint="xxlarge"] .prc-UnderlineNav-ItemsList-oj8gN [data-component="icon"] {
   display: block !important;
 }
 
 nav[aria-label="Repository"] > ul > li > a {
   span[data-component="text"] {
-    opacity: 0 !important;
-    width: 0em !important;
     transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.2) !important;
   }
-  &:hover {
+  &:not(:hover) {
     span[data-component="text"] {
-      opacity: 1 !important;
+      opacity: 0 !important;
+      width: 0em !important;
     }
   }
 }
@@ -341,7 +340,7 @@ nav[aria-label="Repository"] > ul > li > a {
   transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.2) !important;
 }
 
-/* repo sidebar hover $ Revel more info on repository description and below sidebar content on hover */
+/* repo sidebar hover $ Reveal more info on repository description and below sidebar content on hover */
 .Layout-sidebar {
   .BorderGrid-cell {
     .mt-2,


### PR DESCRIPTION
- Force the UnderlineNav icons to display:block so they are no longer hidden by the xxlarge hide-icons breakpoint.
- Only collapse tab text to width:0 when not hovered instead of also forcing a fixed 9em width on hover; let the natural width show.

CSS was made by hand and has been sitting in my userstyles. I only had an agent put them in the right file, push, and regenerate my copy of the json.